### PR TITLE
A $button_label attribute to Kirki_Control_Repeater

### DIFF
--- a/controls/php/class-kirki-control-repeater.php
+++ b/controls/php/class-kirki-control-repeater.php
@@ -52,6 +52,14 @@ class Kirki_Control_Repeater extends Kirki_Control_Base {
 	public $row_label = array();
 
 	/**
+	 * The button label
+	 *
+	 * @access public
+	 * @var string
+	 */
+	public $button_label = '';
+
+	/**
 	 * Constructor.
 	 * Supplied `$args` override class property defaults.
 	 * If `$args['settings']` is not defined, use the $id as the setting ID.


### PR DESCRIPTION
The [__construct method of WP_Customize_Control](https://developer.wordpress.org/reference/classes/wp_customize_control/__construct/) strips out not set object vars. So, if Kirki_Control_Repeater doesn't have a $button_label attribute, the existing test `if ( empty( $this->button_label ) ) {` will always be true.

Creating this attribute seems to solve the problem completely.